### PR TITLE
Do not remove Gutemberg-related scripts and stylesheets if Gutemberg is enabled

### DIFF
--- a/includes/extensions/class-performance.php
+++ b/includes/extensions/class-performance.php
@@ -28,10 +28,11 @@ class WPS_Performance
 
             add_filter('option_active_plugins', [$this, 'disablePlugins']);
 
-            if( !$_config->get('gutenberg', false) )
+            if( !$_config->get('gutenberg', false) ) {
                 add_filter('site_option_active_sitewide_plugins', [$this, 'disableSitewidePlugins']);
+                add_action( 'wp_enqueue_scripts', [$this, 'removeBlockLibrary'], 100 );
+            }
 
-            add_action( 'wp_enqueue_scripts', [$this, 'removeBlockLibrary'], 100 );
             remove_action( 'init', 'check_theme_switched', 99 );
 
             add_action('wp_footer', function (){

--- a/includes/extensions/class-security.php
+++ b/includes/extensions/class-security.php
@@ -106,6 +106,8 @@ class WPS_Security {
 	 */
 	public function cleanHeader()
 	{
+		global $_config;
+
 		remove_action('wp_head', 'feed_links', 2);
 		remove_action('wp_head', 'feed_links_extra', 3 );
 		remove_action('wp_head', 'rsd_link');
@@ -120,11 +122,16 @@ class WPS_Security {
 		remove_action('template_redirect', 'rest_output_link_header', 11 );
 		remove_action('template_redirect', 'wp_shortlink_header', 11 );
 
-		add_action( 'wp_enqueue_scripts', function(){ 
-            wp_dequeue_style( 'wp-block-library' );
-            wp_deregister_script( 'regenerator-runtime' );
-            wp_deregister_script( 'wp-polyfill' );
-        });
+		add_action( 'wp_enqueue_scripts', function(){
+			wp_deregister_script( 'regenerator-runtime' );
+			wp_deregister_script( 'wp-polyfill' );
+		});
+
+		if( !$_config->get('gutenberg', false) ) {
+			add_action( 'wp_enqueue_scripts', function() {
+				wp_dequeue_script('wp-block-library');
+			});
+		}
 
 		add_filter('wp_headers', function($headers) {
 


### PR DESCRIPTION
Hi!

We are using this plugin _with_ Gutemberg enabled, however by default, even if you configure the `gutemberg: true` flag, the plugin removes all built-in blocks CSS and JS.

This change makes that removal conditional on having `gutemberg: false`.